### PR TITLE
narrow down scope for lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.projectlombok', name: 'lombok', version: '1.16.8'
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.16.8'
     compile group: 'args4j', name: 'args4j', version: '2.33'
 
     // Model


### PR DESCRIPTION
Lombok project recommends gradle user to use `compileOnly` to introduce dependency on Lombok.

https://projectlombok.org/mavenrepo/